### PR TITLE
Add Hash Checking to AuthorizeNet gem

### DIFF
--- a/authorize_net.gemspec
+++ b/authorize_net.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = 'authorize_net'
-  spec.version = '0.0.3'
-  spec.date = '2016-03-11'
+  spec.version = '0.1.0'
+  spec.date = '2016-04-21'
   spec.summary = 'API interface for Authorize.net payment gateway'
   spec.description = 'A RubyGem that interfaces with the Authorize.net payment gateway'
   spec.authors = ['Avenir Interactive LLC']

--- a/lib/authorize_net/api.rb
+++ b/lib/authorize_net/api.rb
@@ -80,8 +80,8 @@ class AuthorizeNet::Api
         "id" => customer_profile.merchant_id,
         "email" => customer_profile.email,
         "description" => customer_profile.description,
-        "billTo" => payment_profile.billing_address.to_h,
       },
+      "billTo" => payment_profile.billing_address.to_h,
     }
 
     response = sendRequest("createTransactionRequest", xml_obj)

--- a/lib/authorize_net/exception.rb
+++ b/lib/authorize_net/exception.rb
@@ -5,8 +5,8 @@ class AuthorizeNet::Exception < Exception
   attr_accessor :message
   attr_accessor :errors
 
-  def initialize
-    @message = GENERIC_ERROR_MESSAGE
+  def initialize(message=GENERIC_ERROR_MESSAGE)
+    @message = message
     @errors = []
   end
 


### PR DESCRIPTION
AuthorizeNet allows their vendors to set an md5 hash secret.  That secret string gets rolled up with a bunch of transaction information and hashed, and that hash gets sent with every transaction response to verify the authenticity of the AuthorizeNet server.  This code validates those hash values (if an md5 hash value is present).
