### PR TITLE
[ch37] Upgrade Authorize Net to support sha-512 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out `examples.rb` for some quick examples.
 ## Interface
 ### AuthorizeNet::Api
 To start, you'll want an `AuthorizeNet::Api` object.  The constructor takes your api authorization info.
-`api = AuthorizeNet::Api.new(api_login_id, api_transaction_key, options)`.  Options may contain `:sandbox` which should be true for all sandbox requests, and `:md5_hash` which holds the optional md5_hash value that you can give to AuthorizeNet to validate transactions.
+`api = AuthorizeNet::Api.new(api_login_id, api_transaction_key, **options)`.  Options may contain `:sandbox` which should be true for all sandbox requests, and `:signature_key` which holds the Signature Key string that you can use to validate your transactions.
 
 Then you can start using the below methods to interact with Authorize.net
 

--- a/authorize_net.gemspec
+++ b/authorize_net.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.require_path = 'lib'
   spec.files = Dir["lib/**/*.rb"]
 
-  spec.add_runtime_dependency 'nokogiri', '= 1.6.7.2', '>= 1.6.7.2'
+  spec.required_ruby_version = '>= 2.3.0'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.10', '>= 1.10.2'
 
 end

--- a/authorize_net.gemspec
+++ b/authorize_net.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'authorize_net'
-  spec.version = '0.1.2'
+  spec.version = '1.0.0'
   spec.date = '2016-06-04'
   spec.summary = 'API interface for Authorize.net payment gateway'
   spec.description = 'A RubyGem that interfaces with the Authorize.net payment gateway'

--- a/test/authorize_net/data-object.rb
+++ b/test/authorize_net/data-object.rb
@@ -65,11 +65,11 @@ class TestUtil < Minitest::Test
 
     assert_equal('2', circle1.x)
     assert_equal('4', circle1.y)
-    assert_equal(nil, circle1.radius)
-    assert_equal(nil, circle1.color)
+    assert_nil(circle1.radius)
+    assert_nil(circle1.color)
 
-    assert_equal(nil, circle2.x)
-    assert_equal(nil, circle2.y)
+    assert_nil(circle2.x)
+    assert_nil(circle2.y)
     assert_equal('10', circle2.radius)
     assert_equal('blue', circle2.color)
 
@@ -92,20 +92,20 @@ class TestUtil < Minitest::Test
     test = TestObject.parse(xml)
 
     assert_equal(x.to_s, test.x)
-    assert_equal(nil, test.y)
-    assert_equal(nil, test.radius)
+    assert_nil(test.y)
+    assert_nil(test.radius)
     assert_equal(color, test.color)
   end
 
   def test_parse_bad_xml
     test = TestObject.parse("nothing here")
-    assert_equal(nil, test)
+    assert_nil(test)
 
     test = TestObject.parse({:still => "junk"})
-    assert_equal(nil, test)
+    assert_nil(test)
 
     test= TestObject.parse(1394083120598)
-    assert_equal(nil, test)
+    assert_nil(test)
   end
 
   def test_to_h
@@ -127,9 +127,9 @@ class TestUtil < Minitest::Test
 
     hash2 = test2.to_h
     assert_equal(test2.x, hash2["xVal"])
-    assert_equal(nil, hash2["yVal"])
+    assert_nil(hash2["yVal"])
     assert_equal(test2.color, hash2["color"])
-    assert_equal(nil, hash2["radius"])
+    assert_nil(hash2["radius"])
   end
 
   def test_serialize
@@ -161,8 +161,8 @@ class TestUtil < Minitest::Test
     h_mid = hash[:middle_circle]
     assert_equal(100, h_mid[:x])
     assert_equal(200, h_mid[:y])
-    assert_equal(nil, h_mid[:radius])
-    assert_equal(nil, h_mid[:color])
+    assert_nil(h_mid[:radius])
+    assert_nil(h_mid[:color])
 
     h_c1 = hash[:circles][0]
     assert_equal(1, h_c1[:x])

--- a/test/authorize_net/util.rb
+++ b/test/authorize_net/util.rb
@@ -12,17 +12,17 @@ class TestUtil < Minitest::Test
 
   def test_get_xml_missing_key
     xml = Nokogiri::XML.parse("<randomness>junkjunkjunk</randomness>")
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(xml, "order"))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(xml, "peace"))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(xml, 100))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(xml, {:some_hash => "things"}))
+    assert_nil(AuthorizeNet::Util.getXmlValue(xml, "order"))
+    assert_nil(AuthorizeNet::Util.getXmlValue(xml, "peace"))
+    assert_nil(AuthorizeNet::Util.getXmlValue(xml, 100))
+    assert_nil(AuthorizeNet::Util.getXmlValue(xml, {:some_hash => "things"}))
   end
 
   def test_get_xml_non_xml
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue("blankness", "something"))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(nil, "anything"))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue(1984, "nothing"))
-    assert_equal(nil, AuthorizeNet::Util.getXmlValue({:some_hash => true}, "everything"))
+    assert_nil(AuthorizeNet::Util.getXmlValue("blankness", "something"))
+    assert_nil(AuthorizeNet::Util.getXmlValue(nil, "anything"))
+    assert_nil(AuthorizeNet::Util.getXmlValue(1984, "nothing"))
+    assert_nil(AuthorizeNet::Util.getXmlValue({:some_hash => true}, "everything"))
   end
 
   def test_get_xml_multiple


### PR DESCRIPTION
Also upgrades the `nokogiri` bundle to fix a security issue.